### PR TITLE
Add link to amy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 admintool
 =========
 
+**This project has been replaced by [swcarpentry/amy](https://github.com/swcarpentry/amy). Please consider contributing to that project.**
+
 [![Build Status](https://travis-ci.org/swcarpentry/admintool.svg?branch=master)](https://travis-ci.org/swcarpentry/admintool)
 
 An administration tool for Software Carpentry bootcamps.


### PR DESCRIPTION
Correct me if I'm wrong, but amy is the SWC management application moving forward. This little change in the readme should help direct potential contributors to that project.